### PR TITLE
Pipeline remove docker caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
         - attach_workspace:
               at: ~/repo
         - setup_remote_docker:
-              docker_layer_caching: true
+              docker_layer_caching: false
         # build and push Docker image to dockerhub.
         - run: |
               export VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]'`
@@ -81,13 +81,13 @@ jobs:
     vulnerability-test:
         <<: *defaults
         steps:
-        - checkout 
+        - checkout
         - run:
               name: update-npm
               command: 'sudo npm install -g npm@latest'
         - run:
               name: install-snyk
-              command: 'sudo npm install -g snyk'     
+              command: 'sudo npm install -g snyk'
         - run: # run snyk help - test snyk is installed and working
               name: snyk-help
               command: snyk --help

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grindrodbank/spoon-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A set of reusable React UI components and reducers",
   "license": "MIT",
   "cacheDirectories": [


### PR DESCRIPTION
removed docker caching from pipeline because this is now a "pay-for" feature in circleci.
Bumped the "patch" version to confirm publish to npm as well as github pages.